### PR TITLE
Use the domain part of From

### DIFF
--- a/processors.go
+++ b/processors.go
@@ -142,7 +142,7 @@ func mailProcessor(req *Request) error {
 	ip, _, _ := net.SplitHostPort(req.RemoteAddr)
 
 	// check the spf result
-	req.SPFResult, _, _ = spf.CheckHost(net.ParseIP(ip), fromParts[0], from)
+	req.SPFResult, _, _ = spf.CheckHost(net.ParseIP(ip), fromParts[1], from)
 
 	// check the mx records of the from hostname
 	mxs, err := net.LookupMX(fromParts[1])


### PR DESCRIPTION
Hi @alash3al 

This fixes that SPF uses the first part of From header. Instead it should use the domain: https://github.com/zaccone/spf/blob/76747b8658d9b8686ce812a0e3a2d3be904c980e/spf.go#L122

It's seen here: https://github.com/alash3al/go-smtpsrv/blob/master/processors.go#L139 that it is splitted by 'at'.