### PR TITLE
Allow empty `FROM`

### DIFF
--- a/request.go
+++ b/request.go
@@ -33,6 +33,9 @@ type Request struct {
 	// whether EHLO/HELO called or not
 	HelloRecieved bool
 
+	// whether MAIL FROM was received or not
+	MailFromReceived bool
+
 	// the login username used for login, empty means that this is an anonymous attempt
 	AuthUser string
 
@@ -93,6 +96,7 @@ func (req *Request) Serve() {
 // Reset resets to the defaults
 func (req *Request) Reset() {
 	req.From = ""
+	req.MailFromReceived = false
 	req.To = make([]string, 0)
 	req.Message = nil
 }

--- a/vars.go
+++ b/vars.go
@@ -36,5 +36,5 @@ var (
 )
 
 var (
-	emailRegExp = regexp.MustCompile(`^<((\S+)@(\S+))>$`)
+	emailRegExp = regexp.MustCompile(`^<((\S+)@(\S+))?>$`)
 )


### PR DESCRIPTION
This allows the From address to be empty (`<>`), which is often the case when receiving delivery failure notifications.

As per the RFC (https://tools.ietf.org/html/rfc5321#section-3.6.3):
> One way to prevent loops in error reporting is to specify a null reverse-path
in the MAIL command of a notification message.  When such a message
is transmitted, the reverse-path MUST be set to null (see
Section 4.5.5 for additional discussion).  A MAIL command with a null
reverse-path appears as follows:
>
>   MAIL FROM:<>